### PR TITLE
Adding nuget pkg files

### DIFF
--- a/picojson.nuspec
+++ b/picojson.nuspec
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>PicoJSON</id>
+    <version>1.3.0+1</version>
+    <authors>Kazuho Oku</authors>
+    <owners>Kazuho Oku; Cybozu Labs, Inc.</owners>
+    <projectUrl>https://github.com/kazuho/picojson/</projectUrl>
+    <description>PicoJSON is a tiny JSON parser / serializer for C++ with following properties: 1) header-file only; 2) no external dependencies (only uses standard C++ libraries); 3) STL-frendly (arrays are represented by using std::vector, objects are std::map); 4) provides both pull interface and streaming (event-based) interface.
+    This library is available under a 2-Clause BSD license. See the link to the license for details.
+    This NuGet Pkg was built with Azure Pipeline https://github.com/diogo-strube/build-nuget-picojson.
+    </description>
+    <releaseNotes>Make check is now synonym of Make test and operator= is now safe when part of LHS is being assigned, as well as exception-safe.</releaseNotes>
+    <licenseUrl>https://github.com/kazuho/picojson/blob/master/LICENSE</licenseUrl>
+    <copyright>PicoJSON Copyright © 2011-2015 Kazuho Oku</copyright>
+    <title>PicoJSON - a C++ JSON parser / serializer</title>
+    <summary>PicoJSON is a tiny STL-frendly and header-file only JSON parser / serializer for C++ that has no external dependencies.</summary>
+    <tags>json, parser, C++, header-only</tags>
+    <dependencies>
+      <group targetFramework="native0.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\picojson\picojson.h" target="\lib\native\include\picojson\picojson.h" />
+    <file src="picojson.targets" target="\build\native\picojson.targets" />
+    <file src="..\picojson\README.mkdn" target="docs\" />
+  </files>
+</package>

--- a/picojson.targets
+++ b/picojson.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\..\lib\native\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>


### PR DESCRIPTION
Adding first version of nuspec and target files so that NuGet package can be created.
Sanity check with dev package was done by using the 'pack' command and installing dev package in a test VS solution.